### PR TITLE
Enhance workshop SEO with structured event data

### DIFF
--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -23,7 +23,7 @@ function stripHtml(html) {
  * - Adds canonical + OpenGraph/Twitter cards
  * - Adds Schema.org JSON-LD for Organization + (Article / Workshop)
  *
- * Note: we keep JSON-LD minimal because workshop dates/places are often free-form strings.
+ * Note: workshop dates use the publication date as startDate; places are free-form strings.
  */
 const SEO = ({
   title,
@@ -34,6 +34,9 @@ const SEO = ({
   publishedTime,
   modifiedTime,
   noindex = false,
+  startDate,
+  endDate,
+  eventPlace,
 }) => {
   const data = useStaticQuery(graphql`
     query SeoDefaultsQuery {
@@ -104,17 +107,24 @@ const SEO = ({
     })
   }
 
-  if (type === 'workshop') {
-    // We use a conservative schema shape so we don’t lie about structured fields we can’t guarantee.
+  if (type === ‘workshop’) {
     jsonLd.push({
-      '@context': 'https://schema.org',
-      '@type': 'Event',
+      ‘@context’: ‘https://schema.org’,
+      ‘@type’: ‘Event’,
       name: title,
       description: stripHtml(resolvedDescription),
       url: canonical,
-      organizer: { '@type': 'Organization', name: orgName, url: siteUrl },
+      startDate: startDate || undefined,
+      endDate: endDate || undefined,
+      eventStatus: ‘https://schema.org/EventScheduled’,
+      eventAttendanceMode: ‘https://schema.org/OfflineEventAttendanceMode’,
+      location: eventPlace
+        ? { ‘@type’: ‘Place’, name: eventPlace, address: eventPlace }
+        : undefined,
+      organizer: { ‘@type’: ‘Organization’, name: orgName, url: siteUrl },
+      performer: { ‘@type’: ‘Person’, name: orgName },
       image: ogImage ? [ogImage] : undefined,
-      inLanguage: meta.language || 'es',
+      inLanguage: meta.language || ‘es’,
     })
   }
 

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -107,24 +107,24 @@ const SEO = ({
     })
   }
 
-  if (type === ‘workshop’) {
+  if (type === 'workshop') {
     jsonLd.push({
-      ‘@context’: ‘https://schema.org’,
-      ‘@type’: ‘Event’,
+      '@context': 'https://schema.org',
+      '@type': 'Event',
       name: title,
       description: stripHtml(resolvedDescription),
       url: canonical,
       startDate: startDate || undefined,
       endDate: endDate || undefined,
-      eventStatus: ‘https://schema.org/EventScheduled’,
-      eventAttendanceMode: ‘https://schema.org/OfflineEventAttendanceMode’,
+      eventStatus: 'https://schema.org/EventScheduled',
+      eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
       location: eventPlace
-        ? { ‘@type’: ‘Place’, name: eventPlace, address: eventPlace }
+        ? { '@type': 'Place', name: eventPlace, address: eventPlace }
         : undefined,
-      organizer: { ‘@type’: ‘Organization’, name: orgName, url: siteUrl },
-      performer: { ‘@type’: ‘Person’, name: orgName },
+      organizer: { '@type': 'Organization', name: orgName, url: siteUrl },
+      performer: { '@type': 'Person', name: orgName },
       image: ogImage ? [ogImage] : undefined,
-      inLanguage: meta.language || ‘es’,
+      inLanguage: meta.language || 'es',
     })
   }
 

--- a/src/pages/clases-y-talleres/2019-01-06-taller-biodanza-danzar-desde-el-instinto.md
+++ b/src/pages/clases-y-talleres/2019-01-06-taller-biodanza-danzar-desde-el-instinto.md
@@ -10,6 +10,7 @@ tags:
   - Biodanza
   - Talleres
   - Tarragona
+eventPlace: Tarragona
 featuredImage: /img/the-good-café-1-.png
 ---
 

--- a/src/pages/clases-y-talleres/2019-08-16-bioenergética-movimiento-y-estructuras-de-carácter.md
+++ b/src/pages/clases-y-talleres/2019-08-16-bioenergética-movimiento-y-estructuras-de-carácter.md
@@ -8,6 +8,7 @@ tags:
   - Bioenergética
   - Movimiento
   - Tarragona
+eventPlace: Tarragona
 ---
 "Bioenergética, Movimiento y Estructuras de Carácter"
 

--- a/src/templates/workshop.js
+++ b/src/templates/workshop.js
@@ -192,6 +192,9 @@ const Workshop = ({ data, location }) => {
           post.frontmatter.featuredImage
         }
         publishedTime={post.frontmatter.dateISO}
+        startDate={post.frontmatter.dateISO}
+        endDate={post.frontmatter.expirationDateISO}
+        eventPlace={post.frontmatter.eventPlace}
       />
       <BordersContainer>
         <Container>
@@ -234,6 +237,7 @@ export const pageQuery = graphql`
         featuredImage
         eventDates
         eventPlace
+        expirationDateISO: expirationDate(formatString: "YYYY-MM-DD")
       }
     }
     articles: allMarkdownRemark(


### PR DESCRIPTION
## Summary
This PR improves the SEO markup for workshop pages by expanding the JSON-LD Event schema with additional structured data fields, including event dates, location, and attendance mode information.

## Key Changes
- **SEO Component**: Enhanced the workshop JSON-LD schema to include:
  - `startDate` and `endDate` fields for event scheduling
  - `eventStatus` set to `EventScheduled`
  - `eventAttendanceMode` set to `OfflineEventAttendanceMode`
  - `location` object with place information
  - `performer` field identifying the organization as the event performer
  - Updated component props to accept `startDate`, `endDate`, and `eventPlace` parameters

- **Workshop Template**: Updated to pass workshop-specific metadata to the SEO component:
  - `startDate` from `dateISO` frontmatter field
  - `endDate` from new `expirationDateISO` frontmatter field
  - `eventPlace` from existing `eventPlace` frontmatter field
  - Added `expirationDateISO` to GraphQL query with ISO date formatting

- **Documentation**: Updated the SEO component comment to clarify that workshop dates use the publication date as startDate while places remain free-form strings.

## Implementation Details
- The schema gracefully handles missing optional fields by setting them to `undefined` rather than omitting them, allowing for flexible content
- Event location is represented as a Place object with both name and address fields populated with the same value
- The changes maintain backward compatibility while providing richer structured data for search engines

https://claude.ai/code/session_01GJ7Yfaxmr8yPJZ77WeFRUq