### PR TITLE
Fix missing endDate in workshop Event structured data

### DIFF
--- a/src/templates/workshop.js
+++ b/src/templates/workshop.js
@@ -193,7 +193,7 @@ const Workshop = ({ data, location }) => {
         }
         publishedTime={post.frontmatter.dateISO}
         startDate={post.frontmatter.dateISO}
-        endDate={post.frontmatter.expirationDateISO}
+        endDate={post.frontmatter.expirationDateISO || post.frontmatter.dateISO}
         eventPlace={post.frontmatter.eventPlace}
       />
       <BordersContainer>


### PR DESCRIPTION
Workshop pages without an explicit expirationDate (e.g. the 2019
Biodanza workshop pages) rendered Event JSON-LD without an endDate,
which Search Console flags as a required field. Fall back to the
publish date when no expiration date is set.